### PR TITLE
update readme and point to current NFT example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
-# NFT Standard Implementation
+# NFT Standard Implementation (DEPRECATED)
+
+The NFT implementation in this repository has been deprecated as it does not follow current [NEP-171 standards](https://nomicon.io/Standards/NonFungibleToken/Core.html).
+
+**For the most up-to-date example of NEAR NFT Standard Implementation please visit:** [ https://github.com/near-examples/nft ]


### PR DESCRIPTION
This repository is deprecated and should point to near-examples/nft for the most up-to-date example of NFT standard implementation.